### PR TITLE
Fix error on TensorFlow 1.12 deprecated function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.ipynb_checkpoints/
+traffic-signs-data/*.p

--- a/Traffic_Sign_Classifier.ipynb
+++ b/Traffic_Sign_Classifier.ipynb
@@ -42,8 +42,8 @@
     "#### Environement:\n",
     "-  Ubuntu 16.04\n",
     "-  Anaconda 5.0.1\n",
-    "-  Python 3.6.2\n",
-    "-  TensorFlow 0.12.1 (GPU support)"
+    "-  Python 3.6.6\n",
+    "-  TensorFlow 1.12.0 (GPU support)"
    ]
   },
   {
@@ -65,7 +65,13 @@
     "import os\n",
     "import tensorflow as tf\n",
     "from tensorflow.contrib.layers import flatten\n",
-    "from sklearn.metrics import confusion_matrix"
+    "from sklearn.metrics import confusion_matrix\n",
+    "\n",
+    "# is it using the GPU?\n",
+    "print(tf.test.gpu_device_name())\n",
+    "\n",
+    "# Show current TensorFlow version\n",
+    "tf.__version__"
    ]
   },
   {
@@ -696,7 +702,7 @@
     "\n",
     "        # Training operation\n",
     "        self.one_hot_y = tf.one_hot(y, n_out)\n",
-    "        self.cross_entropy = tf.nn.softmax_cross_entropy_with_logits(self.logits, self.one_hot_y)\n",
+    "        self.cross_entropy = tf.nn.softmax_cross_entropy_with_logits_v2(logits=self.logits, labels=self.one_hot_y)\n",
     "        self.loss_operation = tf.reduce_mean(self.cross_entropy)\n",
     "        self.optimizer = tf.train.AdamOptimizer(learning_rate = learning_rate)\n",
     "        self.training_operation = self.optimizer.minimize(self.loss_operation)\n",
@@ -900,7 +906,7 @@
     "\n",
     "        # Training operation\n",
     "        self.one_hot_y = tf.one_hot(y, n_out)\n",
-    "        self.cross_entropy = tf.nn.softmax_cross_entropy_with_logits(self.logits, self.one_hot_y)\n",
+    "        self.cross_entropy = tf.nn.softmax_cross_entropy_with_logits_v2(logits=self.logits, labels=self.one_hot_y)\n",
     "        self.loss_operation = tf.reduce_mean(self.cross_entropy)\n",
     "        self.optimizer = tf.train.AdamOptimizer(learning_rate = learning_rate)\n",
     "        self.training_operation = self.optimizer.minimize(self.loss_operation)\n",
@@ -1491,7 +1497,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.6"
   },
   "widgets": {
    "state": {},


### PR DESCRIPTION
If running on TensorFlow definitely got an error like this:

```
ValueError                                Traceback (most recent call last)
<ipython-input-40-f67d0aecc114> in <module>()
      1 with tf.name_scope('loss'):
      2     #cross_entropy = None
----> 3     val = tf.nn.softmax_cross_entropy_with_logits(y_conv, y_)
      4     cross_entropy = tf.reduce_mean(val)
      5 

~/anaconda/lib/python3.6/site-packages/tensorflow/python/ops/nn_ops.py in softmax_cross_entropy_with_logits(_sentinel, labels, logits, dim, name)
   1576   """
   1577   _ensure_xent_args("softmax_cross_entropy_with_logits", _sentinel,
-> 1578                     labels, logits)
   1579 
   1580   # TODO(pcmurray) Raise an error when the labels do not sum to 1. Note: This

~/anaconda/lib/python3.6/site-packages/tensorflow/python/ops/nn_ops.py in _ensure_xent_args(name, sentinel, labels, logits)
   1531   if sentinel is not None:
   1532     raise ValueError("Only call `%s` with "
-> 1533                      "named arguments (labels=..., logits=..., ...)" % name)
   1534   if labels is None or logits is None:
   1535     raise ValueError("Both labels and logits must be provided.")

ValueError: Only call `softmax_cross_entropy_with_logits` with named arguments (labels=..., logits=..., ...)
```

fix with new function name and add args name